### PR TITLE
perf: ⚡️ Switch Node Docker base image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.22.0
+FROM node:12-alpine
 
 # Setting Node environment
 ENV NODE_ENV production


### PR DESCRIPTION
Fixes #29.

This has 2 benefits:
- The Docker image size is decreased from 988MB -> 170MB
- `docker-compose stop` of the container is faster. About 12s faster according to @FantasticoFox

cc: @hung-pelith 